### PR TITLE
Improve download speed by manipulating Aria2 command line flags

### DIFF
--- a/colab_leecher/downlader/aria2.py
+++ b/colab_leecher/downlader/aria2.py
@@ -24,6 +24,8 @@ async def aria2_Download(link: str, num: int):
         "--max-tries=3",
         "--console-log-level=notice",
         "-d",
+        "--max-concurrent-downloads=99,
+        "--split=1M", # Minimum possible value. Default is 20M.
         Paths.down_path,
         link,
     ]


### PR DESCRIPTION
I [myself](https://github.com/hstsethi/no-frills-dotfiles/blob/main/aria2/aria2.conf) use these flags. This makes it pretty fast.